### PR TITLE
Add asynchronous request to curl

### DIFF
--- a/src/Events/DatabaseTransactionEvent.php
+++ b/src/Events/DatabaseTransactionEvent.php
@@ -24,6 +24,8 @@ class DatabaseTransactionEvent extends BaseEvent implements Event
 
         $this->setOption(CURLOPT_URL, $endpoint);
         $this->setOption(CURLOPT_RETURNTRANSFER, true);
+        $this->setOption(CURLOPT_HEADER, false);
+        $this->setOption(CURLOPT_RETURNTRANSFER, false);
         $this->setOption(
             CURLOPT_POSTFIELDS,
             $this->generatePayload($data, self::EVENT_TYPE)

--- a/src/Events/LogEvent.php
+++ b/src/Events/LogEvent.php
@@ -50,6 +50,8 @@ class LogEvent extends BaseEvent implements Event
 
         $this->setOption(CURLOPT_URL, $endpoint);
         $this->setOption(CURLOPT_RETURNTRANSFER, true);
+        $this->setOption(CURLOPT_HEADER, false);
+        $this->setOption(CURLOPT_RETURNTRANSFER, false);
         $this->setOption(
             CURLOPT_POSTFIELDS,
             $this->generatePayload($data, self::EVENT_TYPE)


### PR DESCRIPTION
- added `CURLOPT_HEADER` and `CURLOPT_RETURNTRANSFER` to false
	- CURLOPT_HEADER set to false tells that we do not care about the headers sent back by the server
	- CURLOPT_RETURNTRANSFER set to false tells that we do not care about the response body from the server